### PR TITLE
fix: incorrect quality frame rate passed in android

### DIFF
--- a/android/src/main/java/com/reactnativeamazonivs/AmazonIvsView.kt
+++ b/android/src/main/java/com/reactnativeamazonivs/AmazonIvsView.kt
@@ -274,7 +274,7 @@ class AmazonIvsView(private val context: ThemedReactContext) : FrameLayout(conte
           parsedQuality.putString("name", quality.name)
           parsedQuality.putString("codecs", quality.codecs)
           parsedQuality.putInt("bitrate", quality.bitrate)
-          parsedQuality.putInt("framerate", quality.framerate.toInt())
+          parsedQuality.putDouble("framerate", quality.framerate.toDouble())
           parsedQuality.putInt("width", quality.width)
           parsedQuality.putInt("height", quality.height)
           qualities.pushMap(parsedQuality)
@@ -298,7 +298,7 @@ class AmazonIvsView(private val context: ThemedReactContext) : FrameLayout(conte
     newQuality.putString("name", quality.name)
     newQuality.putString("codecs", quality.codecs)
     newQuality.putInt("bitrate", quality.bitrate)
-    newQuality.putInt("framerate", quality.framerate.toInt())
+    newQuality.putDouble("framerate", quality.framerate.toDouble())
     newQuality.putInt("width", quality.width)
     newQuality.putInt("height", quality.height)
 


### PR DESCRIPTION
Fix issue where in android the quality frame rate is wrong.

Currently
iOS:
```
  {
      "bitrate": 626300,
      "codecs": "avc1.4d401f,mp4a.40.5",
      "framerate": 29.969999313354492,
      "height": 480,
      "name": "480p",
      "width": 852
  }
```
Android:
```
 {
      "bitrate": 626300,
      "codecs": "avc1.4d401f,mp4a.40.5",
      "framerate": 29,
      "height": 480,
      "name": "480p",
      "width": 852
  }
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.