### PR TITLE
chore: add framework name/version to AmazonIvsManager

### DIFF
--- a/amazon-ivs-react-native.podspec
+++ b/amazon-ivs-react-native.podspec
@@ -2,6 +2,15 @@ require "json"
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 
+File.open("ios/AmazonIvsManager+Framework.swift", "w") { |f|
+  f.write <<-IVS
+extension AmazonIvsManager {
+  @objc public static let frameworkName = "reactnative"
+  @objc public static let frameworkVersion = "#{package["version"]}"
+}
+IVS
+}
+
 Pod::Spec.new do |s|
   s.name         = "amazon-ivs-react-native"
   s.version      = package["version"]

--- a/ios/.gitignore
+++ b/ios/.gitignore
@@ -1,0 +1,1 @@
+AmazonIvsManager+Framework.swift


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Adds the framework name and version as (generated) static properties on the `AmazonIvsManager` class.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
